### PR TITLE
[Feature] 요양보호사 및 보호대상자 계정

### DIFF
--- a/src/main/java/com/team_3/nursing_care/domain/member/constant/Role.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/constant/Role.java
@@ -7,7 +7,7 @@ public enum Role {
 
     ADMIN("관리자", Authority.ADMIN),
     CAREGIVER("요양보호사", Authority.CAREGIVER),
-    PATIENT("보호대상자", Authority.PATIENT),;
+    PATIENT("보호자", Authority.PATIENT);
 
     private final String displayName;
     private final String authority;

--- a/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
@@ -3,8 +3,10 @@ package com.team_3.nursing_care.domain.member.controller;
 import com.team_3.nursing_care.common.response.PageResponseDto;
 import com.team_3.nursing_care.common.response.ResponseDto;
 import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
+import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
 import com.team_3.nursing_care.domain.member.service.AccountService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,10 +15,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.team_3.nursing_care.common.exception.ResultMessage.Success;
 import static software.amazon.awssdk.http.HttpStatusCode.OK;
@@ -38,6 +37,13 @@ public class AccountController {
         Page<AccountListResponseDto> accountPage = accountService.getAccountList(searchName, searchRole, userDetails, pageable);
         return ResponseEntity.ok(new ResponseDto<>(OK, Success, new PageResponseDto<>(accountPage)));
 
+    }
+
+    @PostMapping("/{memberId}")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> createAccount(@PathVariable("memberId") Long memberId, @Valid @RequestBody CreateAccountRequestDto dto) {
+        accountService.addAccount(memberId, dto);
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, "계정이 정상적으로 등록 되었습니다."));
     }
 
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
@@ -34,11 +34,18 @@ public class AccountController {
     public ResponseEntity<?> getAccountList(@RequestParam(name = "searchName", required = false) String searchName,
                                             @RequestParam(name = "searchRole", required = false) String searchRole,
                                             @AuthenticationPrincipal CustomUserDetails userDetails,
-                                            @PageableDefault(size = 10, sort = "memberId", direction = Sort.Direction.DESC) Pageable pageable) {
+                                            @PageableDefault(size = 10, sort = "loginId", direction = Sort.Direction.ASC) Pageable pageable) {
 
         Page<AccountListResponseDto> accountPage = accountService.getAccountList(searchName, searchRole, userDetails, pageable);
         return ResponseEntity.ok(new ResponseDto<>(OK, Success, new PageResponseDto<>(accountPage)));
 
+    }
+
+    @GetMapping("/member-name-list")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> getMemberNameList(@RequestParam(name = "role") String role, @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, accountService.getMemberNameList(role, userDetails)));
     }
 
     @GetMapping("/id/{memberId}")
@@ -69,5 +76,11 @@ public class AccountController {
         return ResponseEntity.ok(new ResponseDto<>(OK, Success, "계정 비밀번호가 정상적으로 변경 되었습니다."));
     }
 
+    @DeleteMapping("/{memberId}")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> deleteAccount(@PathVariable("memberId") Long memberId){
+        accountService.deleteAccount(memberId);
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, "로그인 계정 정보가 정상적으로 삭제되었습니다."));
+    }
 
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
@@ -1,0 +1,43 @@
+package com.team_3.nursing_care.domain.member.controller;
+
+import com.team_3.nursing_care.common.response.PageResponseDto;
+import com.team_3.nursing_care.common.response.ResponseDto;
+import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
+import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import com.team_3.nursing_care.domain.member.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.team_3.nursing_care.common.exception.ResultMessage.Success;
+import static software.amazon.awssdk.http.HttpStatusCode.OK;
+
+@RestController
+@RequestMapping("/api/v1/member/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @GetMapping("/list")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> getAccountList(@RequestParam(name = "searchName", required = false) String searchName,
+                                            @RequestParam(name = "searchRole", required = false) String searchRole,
+                                            @AuthenticationPrincipal CustomUserDetails userDetails,
+                                            @PageableDefault(size = 10, sort = "memberId", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<AccountListResponseDto> accountPage = accountService.getAccountList(searchName, searchRole, userDetails, pageable);
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, new PageResponseDto<>(accountPage)));
+
+    }
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/controller/AccountController.java
@@ -4,6 +4,8 @@ import com.team_3.nursing_care.common.response.PageResponseDto;
 import com.team_3.nursing_care.common.response.ResponseDto;
 import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
 import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto;
+import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginIdRequestDto;
+import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginPwRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
 import com.team_3.nursing_care.domain.member.service.AccountService;
 import jakarta.validation.Valid;
@@ -39,11 +41,33 @@ public class AccountController {
 
     }
 
+    @GetMapping("/id/{memberId}")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> getId(@PathVariable("memberId") Long memberId) {
+
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, accountService.getLoginId(memberId)));
+    }
+
     @PostMapping("/{memberId}")
     @PreAuthorize("hasAnyRole('ADMIN')")
     public ResponseEntity<?> createAccount(@PathVariable("memberId") Long memberId, @Valid @RequestBody CreateAccountRequestDto dto) {
         accountService.addAccount(memberId, dto);
         return ResponseEntity.ok(new ResponseDto<>(OK, Success, "계정이 정상적으로 등록 되었습니다."));
     }
+
+    @PatchMapping("/id/{memberId}")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> updateLoginId(@PathVariable("memberId") Long memberId, @RequestBody @Valid UpdateLoginIdRequestDto updateLoginIdRequestDto) {
+        accountService.updateLoginId(memberId, updateLoginIdRequestDto);
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, "계정 아이디가 정상적으로 변경 되었습니다."));
+    }
+
+    @PatchMapping("/pw/{memberId}")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> updateLoginPw(@PathVariable("memberId") Long memberId, @RequestBody @Valid UpdateLoginPwRequestDto updateLoginPwRequestDto) {
+        accountService.updateLoginPw(memberId, updateLoginPwRequestDto);
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, "계정 비밀번호가 정상적으로 변경 되었습니다."));
+    }
+
 
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/controller/MemberController.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/controller/MemberController.java
@@ -28,9 +28,13 @@ public class MemberController {
     }
 
     @GetMapping("/patient-name-list/{companyId}")
-    public ResponseEntity<ResponseDto<PatientsNameListResponseDto>> getPatientNameList(@PathVariable Long companyId){
+    public ResponseEntity<ResponseDto<PatientsNameListResponseDto>> getPatientNameList(@PathVariable Long companyId) {
         return ResponseEntity.ok((new ResponseDto<>(OK, ResultMessage.Success, memberService.getPatientsName(companyId, Role.PATIENT))));
     }
 
+    @GetMapping("/role-name-list")
+    public ResponseEntity<?> getRoleNameList() {
+        return ResponseEntity.ok((new ResponseDto<>(OK, ResultMessage.Success, memberService.getRoleName())));
+    }
 
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/dto/request/CreateAccountRequestDto.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/dto/request/CreateAccountRequestDto.java
@@ -1,0 +1,20 @@
+package com.team_3.nursing_care.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class CreateAccountRequestDto {
+
+    @NotBlank
+    private String loginId;
+    @NotBlank
+    private String loginPw;
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/dto/request/UpdateLoginIdRequestDto.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/dto/request/UpdateLoginIdRequestDto.java
@@ -1,0 +1,16 @@
+package com.team_3.nursing_care.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateLoginIdRequestDto {
+
+    @NotBlank(message = "loginNewId 는 필수 항목입니다.")
+    private String loginNewId;
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/dto/request/UpdateLoginPwRequestDto.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/dto/request/UpdateLoginPwRequestDto.java
@@ -1,0 +1,18 @@
+package com.team_3.nursing_care.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateLoginPwRequestDto {
+
+    @NotBlank(message = "loginNewPw 는 필수 항목입니다.")
+    private String loginNewPw;
+    @NotBlank(message = "loginNewPwConfirm 는 필수 항목입니다.")
+    private String loginNewPwConfirm;
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/dto/response/AccountListResponseDto.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/dto/response/AccountListResponseDto.java
@@ -1,0 +1,40 @@
+package com.team_3.nursing_care.domain.member.dto.response;
+
+import com.team_3.nursing_care.domain.member.entity.Member;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccountListResponseDto {
+
+    private Long memberId;
+    private String loginId;
+    private String name;
+    private String role;
+    private String patientName;
+    private LocalDateTime lastLoginAt;
+
+    public static AccountListResponseDto create(Member member) {
+        String guardianName = null;
+        if (member.getPatientInfo() != null) {
+            guardianName = member.getPatientInfo().getGuardianName();
+        }
+
+        boolean hasGuardian = guardianName != null && !guardianName.isBlank();
+
+        return AccountListResponseDto.builder()
+                .memberId(member.getMemberId())
+                .loginId(member.getLoginId())
+                .name(hasGuardian ? guardianName : member.getMemberName())
+                .role(member.getRole().getDisplayName())
+                .patientName(hasGuardian ? member.getMemberName() : null)
+                .lastLoginAt(member.getLastLoginAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/dto/response/MemberNameResponseDto.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/dto/response/MemberNameResponseDto.java
@@ -1,0 +1,20 @@
+package com.team_3.nursing_care.domain.member.dto.response;
+
+import com.team_3.nursing_care.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberNameResponseDto {
+
+    Long memberId;
+    String name;
+
+    public static MemberNameResponseDto from(Member member){
+        return new MemberNameResponseDto(member.getMemberId(), member.getMemberName());
+    }
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/dto/response/RoleNameResponseDto.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/dto/response/RoleNameResponseDto.java
@@ -1,0 +1,19 @@
+package com.team_3.nursing_care.domain.member.dto.response;
+
+import com.team_3.nursing_care.domain.member.constant.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class RoleNameResponseDto {
+
+    private String name;
+    private String displayName;
+
+    public static RoleNameResponseDto from(Role role) {
+        return new RoleNameResponseDto(role.name(), role.getDisplayName());
+    }
+
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/dto/response/UpdateAccountResponseDto.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/dto/response/UpdateAccountResponseDto.java
@@ -1,0 +1,18 @@
+package com.team_3.nursing_care.domain.member.dto.response;
+
+import com.team_3.nursing_care.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UpdateAccountResponseDto {
+
+    private Long memberId;
+    private String loginId;
+
+    public static UpdateAccountResponseDto from(Member member) {
+        return new UpdateAccountResponseDto(member.getMemberId(), member.getLoginId());
+    }
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
@@ -123,4 +123,8 @@ public class Member extends BaseEntity {
     public void updateIsDeleted(Boolean isDeleted) {
         this.isDeleted = isDeleted;
     }
+
+    public void updateAccountIsDeleted(Boolean accountIsDeleted) {
+        this.accountIsDeleted = accountIsDeleted;
+    }
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
@@ -43,10 +43,14 @@ public class Member extends BaseEntity {
     private String certificateNumber;
     private short career;
 
+    @Setter
     private LocalDateTime lastLoginAt;
 
     private String loginId;
     private String loginPw;
+
+    @Builder.Default
+    private Boolean accountIsDeleted = false;
 
     @Setter
     private String refreshToken;
@@ -99,7 +103,7 @@ public class Member extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public void updatePatient(UpdatePatientRequestDto dto, String profileImageUrl){
+    public void updatePatient(UpdatePatientRequestDto dto, String profileImageUrl) {
         this.memberName = dto.getName();
         this.birthDate = dto.getBirthDate();
         this.address = dto.getAddress();

--- a/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
@@ -112,6 +112,11 @@ public class Member extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void updateAccount(String loginId, String loginPw) {
+        this.loginId = loginId;
+        this.loginPw = loginPw;
+    }
+
     public void updateIsDeleted(Boolean isDeleted) {
         this.isDeleted = isDeleted;
     }

--- a/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/entity/Member.java
@@ -112,8 +112,11 @@ public class Member extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public void updateAccount(String loginId, String loginPw) {
+    public void updateLoginId(String loginId) {
         this.loginId = loginId;
+    }
+
+    public void updateLoginPw(String loginPw) {
         this.loginPw = loginPw;
     }
 

--- a/src/main/java/com/team_3/nursing_care/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/repository/MemberRepository.java
@@ -19,6 +19,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findByCompany_CompanyIdAndRole(Long companyId, Role role);
 
+    List<Member> findByCompany_CompanyIdAndRoleAndLoginIdIsNull(Long comapnyId, Role role);
+
     Optional<Member> findByMemberIdAndRole(Long memberId, Role role);
 
     Optional<Member> findByLoginId(String loginId);

--- a/src/main/java/com/team_3/nursing_care/domain/member/repository/custom/MemberCustomRepository.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/repository/custom/MemberCustomRepository.java
@@ -1,0 +1,9 @@
+package com.team_3.nursing_care.domain.member.repository.custom;
+
+import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MemberCustomRepository {
+    Page<AccountListResponseDto> getAccountList(Long companyId, String searchName, String searchRole, Pageable pageable);
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/repository/custom/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/repository/custom/MemberCustomRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.team_3.nursing_care.domain.member.repository.custom;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team_3.nursing_care.domain.member.constant.Role;
+import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.team_3.nursing_care.domain.member.entity.QMember.member;
+import static com.team_3.nursing_care.domain.member.entity.QPatientInfo.patientInfo;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberCustomRepositoryImpl implements MemberCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AccountListResponseDto> getAccountList(Long companyId, String searchName, String searchRole, Pageable pageable) {
+        Role role;
+
+        BooleanBuilder whereClause = new BooleanBuilder();
+        whereClause.and(member.company.companyId.eq(companyId));
+        whereClause.and(member.accountIsDeleted.eq(false));
+
+        if (searchName != null && !searchName.isBlank()) {
+            whereClause.and(
+                    member.memberName.contains(searchName)
+                            .or(member.loginId.contains(searchName))
+            );
+        }
+
+        if (searchRole != null) {
+            try {
+                role = Role.valueOf(searchRole.toUpperCase());
+
+                if (role != null) {
+                    whereClause.and(member.role.eq(role));
+                }
+
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("존재하지 않는 권한입니다: " + searchRole);
+            }
+        }
+
+        List<AccountListResponseDto> content = queryFactory
+                .selectFrom(member)
+                .leftJoin(member.patientInfo, patientInfo).fetchJoin()
+                .where(whereClause)
+                .orderBy(getOrderBy(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream()
+                .map(AccountListResponseDto::create)
+                .toList();
+
+        JPAQuery<Long> countQuery = queryFactory.select(member.count())
+                .from(member)
+                .where(whereClause);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private OrderSpecifier<?>[] getOrderBy(Sort sort) {
+        return sort.stream()
+                .map(order -> {
+                    if (order.getProperty().equals("memberId")) {
+                        return order.isAscending() ? member.memberId.asc() : member.memberId.desc();
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .toArray(OrderSpecifier[]::new);
+    }
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/repository/custom/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/repository/custom/MemberCustomRepositoryImpl.java
@@ -32,6 +32,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
         BooleanBuilder whereClause = new BooleanBuilder();
         whereClause.and(member.company.companyId.eq(companyId));
         whereClause.and(member.accountIsDeleted.eq(false));
+        whereClause.and(member.loginId.isNotNull());
 
         if (searchName != null && !searchName.isBlank()) {
             whereClause.and(
@@ -75,8 +76,8 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     private OrderSpecifier<?>[] getOrderBy(Sort sort) {
         return sort.stream()
                 .map(order -> {
-                    if (order.getProperty().equals("memberId")) {
-                        return order.isAscending() ? member.memberId.asc() : member.memberId.desc();
+                    if (order.getProperty().equals("loginId")) {
+                        return order.isAscending() ? member.loginId.asc() : member.loginId.desc();
                     }
                     return null;
                 })

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
@@ -1,0 +1,13 @@
+package com.team_3.nursing_care.domain.member.service;
+
+import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
+import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AccountService {
+
+    Page<AccountListResponseDto> getAccountList(String searchName, String searchRole, CustomUserDetails userDetails, Pageable pageable);
+
+
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
@@ -1,6 +1,7 @@
 package com.team_3.nursing_care.domain.member.service;
 
 import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
+import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,5 +10,5 @@ public interface AccountService {
 
     Page<AccountListResponseDto> getAccountList(String searchName, String searchRole, CustomUserDetails userDetails, Pageable pageable);
 
-
+    void addAccount(Long memberId, CreateAccountRequestDto dto);
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
@@ -5,13 +5,18 @@ import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto
 import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginIdRequestDto;
 import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginPwRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import com.team_3.nursing_care.domain.member.dto.response.MemberNameResponseDto;
 import com.team_3.nursing_care.domain.member.dto.response.UpdateAccountResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface AccountService {
 
     Page<AccountListResponseDto> getAccountList(String searchName, String searchRole, CustomUserDetails userDetails, Pageable pageable);
+
+    List<MemberNameResponseDto> getMemberNameList(String role, CustomUserDetails userDetails);
 
     UpdateAccountResponseDto getLoginId(Long memberId);
 
@@ -20,4 +25,6 @@ public interface AccountService {
     void updateLoginId(Long memberId, UpdateLoginIdRequestDto updateLoginIdRequestDto);
 
     void updateLoginPw(Long memberId, UpdateLoginPwRequestDto updateLoginPwRequestDto);
+
+    void deleteAccount(Long memberId);
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountService.java
@@ -2,7 +2,10 @@ package com.team_3.nursing_care.domain.member.service;
 
 import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
 import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto;
+import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginIdRequestDto;
+import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginPwRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import com.team_3.nursing_care.domain.member.dto.response.UpdateAccountResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,5 +13,11 @@ public interface AccountService {
 
     Page<AccountListResponseDto> getAccountList(String searchName, String searchRole, CustomUserDetails userDetails, Pageable pageable);
 
+    UpdateAccountResponseDto getLoginId(Long memberId);
+
     void addAccount(Long memberId, CreateAccountRequestDto dto);
+
+    void updateLoginId(Long memberId, UpdateLoginIdRequestDto updateLoginIdRequestDto);
+
+    void updateLoginPw(Long memberId, UpdateLoginPwRequestDto updateLoginPwRequestDto);
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
@@ -3,7 +3,10 @@ package com.team_3.nursing_care.domain.member.service;
 import com.team_3.nursing_care.common.exception.MemberException;
 import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
 import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto;
+import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginIdRequestDto;
+import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginPwRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import com.team_3.nursing_care.domain.member.dto.response.UpdateAccountResponseDto;
 import com.team_3.nursing_care.domain.member.entity.Member;
 import com.team_3.nursing_care.domain.member.repository.MemberRepository;
 import com.team_3.nursing_care.domain.member.repository.custom.MemberCustomRepository;
@@ -34,6 +37,17 @@ public class AccountServiceImpl implements AccountService {
 
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public UpdateAccountResponseDto getLoginId(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 멤버를 찾을 수 없습니다."));
+
+        return UpdateAccountResponseDto.from(member);
+
+    }
+
     @Transactional
     @Override
     public void addAccount(Long memberId, CreateAccountRequestDto dto) {
@@ -47,8 +61,41 @@ public class AccountServiceImpl implements AccountService {
 
         String encodePw = passwordEncoder.encode(dto.getLoginPw());
 
-        member.updateAccount(dto.getLoginId(), encodePw);
+        member.updateLoginId(dto.getLoginId());
+        member.updateLoginPw(encodePw);
 
+    }
+
+    @Transactional
+    @Override
+    public void updateLoginId(Long memberId, UpdateLoginIdRequestDto updateLoginIdRequestDto) {
+        Member member = memberRepository.findByLoginId(updateLoginIdRequestDto.getLoginNewId()).orElse(null);
+
+        String loginNewId = updateLoginIdRequestDto.getLoginNewId();
+
+        if (member != null)
+            throw new MemberException(HttpStatusCode.BAD_REQUEST, "duplicate login id: " + loginNewId);
+
+        member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 멤버를 찾을 수 없습니다."));
+
+        member.updateLoginId(loginNewId);
+    }
+
+    @Transactional
+    @Override
+    public void updateLoginPw(Long memberId, UpdateLoginPwRequestDto updateLoginPwRequestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 멤버를 찾을 수 없습니다."));
+
+        String loginNewPw = updateLoginPwRequestDto.getLoginNewPw();
+
+        if (!loginNewPw.equals(updateLoginPwRequestDto.getLoginNewPwConfirm()))
+            throw new MemberException(HttpStatusCode.BAD_REQUEST, "not match login password Confirm");
+
+        String encodePw = passwordEncoder.encode(loginNewPw);
+
+        member.updateLoginPw(encodePw);
     }
 
 

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
@@ -1,14 +1,20 @@
 package com.team_3.nursing_care.domain.member.service;
 
+import com.team_3.nursing_care.common.exception.MemberException;
 import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
+import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import com.team_3.nursing_care.domain.member.entity.Member;
 import com.team_3.nursing_care.domain.member.repository.MemberRepository;
 import com.team_3.nursing_care.domain.member.repository.custom.MemberCustomRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.http.HttpStatusCode;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +22,7 @@ public class AccountServiceImpl implements AccountService {
 
     private final MemberRepository memberRepository;
     private final MemberCustomRepository memberCustomRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     @Override
@@ -26,4 +33,23 @@ public class AccountServiceImpl implements AccountService {
         return memberCustomRepository.getAccountList(companyId, searchName, searchRole, pageable);
 
     }
+
+    @Transactional
+    @Override
+    public void addAccount(Long memberId, CreateAccountRequestDto dto) {
+
+        Member member = memberRepository.findByLoginId(dto.getLoginId()).orElse(null);
+        if (member != null)
+            throw new MemberException(HttpStatusCode.BAD_REQUEST, "duplicate login id: " + dto.getLoginId());
+
+        member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 멤버를 찾을 수 없습니다."));
+
+        String encodePw = passwordEncoder.encode(dto.getLoginPw());
+
+        member.updateAccount(dto.getLoginId(), encodePw);
+
+    }
+
+
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
@@ -1,0 +1,29 @@
+package com.team_3.nursing_care.domain.member.service;
+
+import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
+import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import com.team_3.nursing_care.domain.member.repository.MemberRepository;
+import com.team_3.nursing_care.domain.member.repository.custom.MemberCustomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AccountServiceImpl implements AccountService {
+
+    private final MemberRepository memberRepository;
+    private final MemberCustomRepository memberCustomRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<AccountListResponseDto> getAccountList(String searchName, String searchRole, CustomUserDetails userDetails, Pageable pageable) {
+
+        Long companyId = userDetails.getCompanyId();
+
+        return memberCustomRepository.getAccountList(companyId, searchName, searchRole, pageable);
+
+    }
+}

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/AccountServiceImpl.java
@@ -2,10 +2,12 @@ package com.team_3.nursing_care.domain.member.service;
 
 import com.team_3.nursing_care.common.exception.MemberException;
 import com.team_3.nursing_care.common.security.user.custom.CustomUserDetails;
+import com.team_3.nursing_care.domain.member.constant.Role;
 import com.team_3.nursing_care.domain.member.dto.request.CreateAccountRequestDto;
 import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginIdRequestDto;
 import com.team_3.nursing_care.domain.member.dto.request.UpdateLoginPwRequestDto;
 import com.team_3.nursing_care.domain.member.dto.response.AccountListResponseDto;
+import com.team_3.nursing_care.domain.member.dto.response.MemberNameResponseDto;
 import com.team_3.nursing_care.domain.member.dto.response.UpdateAccountResponseDto;
 import com.team_3.nursing_care.domain.member.entity.Member;
 import com.team_3.nursing_care.domain.member.repository.MemberRepository;
@@ -18,6 +20,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.http.HttpStatusCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +41,29 @@ public class AccountServiceImpl implements AccountService {
         return memberCustomRepository.getAccountList(companyId, searchName, searchRole, pageable);
 
     }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<MemberNameResponseDto> getMemberNameList(String role, CustomUserDetails userDetails) {
+
+        Long companyId = userDetails.getCompanyId();
+
+        Role realRole;
+        try {
+            realRole = Role.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException("유효하지 않은 권한입니다: " + role);
+        }
+
+        List<Member> members = memberRepository.findByCompany_CompanyIdAndRoleAndLoginIdIsNull(companyId,realRole);
+
+        List<MemberNameResponseDto> dtoList = members.stream()
+                .map(MemberNameResponseDto::from)
+                .collect(Collectors.toList());
+
+        return dtoList;
+    }
+
 
     @Transactional(readOnly = true)
     @Override
@@ -96,6 +124,15 @@ public class AccountServiceImpl implements AccountService {
         String encodePw = passwordEncoder.encode(loginNewPw);
 
         member.updateLoginPw(encodePw);
+    }
+
+    @Transactional
+    @Override
+    public void deleteAccount(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 멤버를 찾을 수 없습니다."));
+
+        member.updateAccountIsDeleted(true);
     }
 
 

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/CaregiverService.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/CaregiverService.java
@@ -10,7 +10,6 @@ import com.team_3.nursing_care.domain.member.dto.response.UpdateCaregiverRespons
 import com.team_3.nursing_care.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface CaregiverService {

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/MemberService.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/MemberService.java
@@ -6,12 +6,17 @@ import com.team_3.nursing_care.domain.member.dto.request.ReqSignUpDto;
 import com.team_3.nursing_care.domain.member.dto.response.CaregiversNameListResponseDto;
 import com.team_3.nursing_care.domain.member.dto.response.PatientsNameListResponseDto;
 import com.team_3.nursing_care.domain.member.dto.response.ResLoginDto;
+import com.team_3.nursing_care.domain.member.dto.response.RoleNameResponseDto;
+
+import java.util.List;
 
 public interface MemberService {
 
     CaregiversNameListResponseDto getCaregiversName(Long companyId, Role role);
 
     PatientsNameListResponseDto getPatientsName(Long companyId, Role role);
+
+    List<RoleNameResponseDto> getRoleName();
 
     void signup(ReqSignUpDto reqSignUpDto);
 

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/MemberServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.http.HttpStatusCode;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -96,6 +97,7 @@ public class MemberServiceImpl implements MemberService {
         String refreshToken = jwtUtil.createRefreshToken(member.getMemberId(), roles);
 
         member.setRefreshToken(refreshToken);
+        member.setLastLoginAt(LocalDateTime.now());
         memberRepository.save(member);
 
         return ResLoginDto.create(accessToken, refreshToken);

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/MemberServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.http.HttpStatusCode;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -58,6 +59,15 @@ public class MemberServiceImpl implements MemberService {
 
         return PatientsNameListResponseDto.from(patientsList);
     }
+
+    @Override
+    public List<RoleNameResponseDto> getRoleName() {
+        return Arrays.stream(Role.values())
+                .filter(role -> role != Role.ADMIN)
+                .map(RoleNameResponseDto::from)
+                .toList();
+    }
+
 
     @Override
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> #83 #84 #85 #86 

## 📝작업 내용

> 관리자 계정에서 이미 등록된 요양보호사 및 보호대상자의 정보에 대해 계정을 조회, 생성, 수정, 삭제하는 기능을 구현하였습니다.

### 스크린샷 (선택)

> Read Account List

![ReadAccountList1](https://github.com/user-attachments/assets/b73f15e5-1ac5-41b4-8a21-22ec41d49fa6)

> Add Account

![CreateAccountInfo](https://github.com/user-attachments/assets/793ffc83-458c-4978-9443-702ff127fdf2)

> Update Account

![UpdateLoginId](https://github.com/user-attachments/assets/8c13cc02-d36d-4bc0-9b24-439042ccef0d)

![UpdateLoginPw](https://github.com/user-attachments/assets/3a0cdac4-7f95-4c23-b209-d841cc2135a5)

> Delete Account

![DeleteAccount](https://github.com/user-attachments/assets/512fe205-191b-492a-b0d2-1fc6e2893bb6)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
