### PR TITLE
:hammer: refactor: 요양 보호사 dashboard 조회 시 workday filter 추가

### DIFF
--- a/src/main/java/com/team_3/nursing_care/domain/member/controller/CaregiverController.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/controller/CaregiverController.java
@@ -86,9 +86,9 @@ public class CaregiverController {
         return ResponseEntity.ok(new ResponseDto<>(OK, Success, "요양보호사 정보가 정상적으로 삭제되었습니다."));
     }
 
-    @GetMapping("/dashboard/{caregiverId}")
-    public ResponseEntity<ResponseDto<CaregiverDashboardResDto>> getCaregiverDashBoard(@PathVariable Long caregiverId){
-        return ResponseEntity.ok(new ResponseDto<>(OK, Success, caregiverService.getCaregiverDashBoard(caregiverId)));
+    @GetMapping("/dashboard")
+    public ResponseEntity<ResponseDto<CaregiverDashboardResDto>> getCaregiverDashBoard(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return ResponseEntity.ok(new ResponseDto<>(OK, Success, caregiverService.getCaregiverDashBoard(userDetails.getMemberId())));
     }
 
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/CaregiverServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/CaregiverServiceImpl.java
@@ -159,6 +159,10 @@ public class CaregiverServiceImpl implements CaregiverService {
         List<Schedule> schedules = scheduleRepository.findByMemberIdAndScheduleDate(caregiverId, today);
 
         List<CaregiverScheduleResDto> scheduleDtos = schedules.stream()
+                .filter(schedule -> {
+                        int dayOfWeekBit = 1 << (today.getDayOfWeek().getValue() - 1);
+                        return (schedule.getWorkDay() & dayOfWeekBit) != 0;
+                })
                 .map(schedule -> {
                     String patientName = memberRepository.findById(schedule.getPatientId())
                             .map(Member::getMemberName)
@@ -183,7 +187,6 @@ public class CaregiverServiceImpl implements CaregiverService {
                             .build();
                 })
                 .toList();
-
         return CaregiverDashboardResDto.builder()
                 .caregiverName(name)
                 .schedules(scheduleDtos)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 요양 보호사 대시보드 화면에 보여질때, 근무일정으로 오늘 일정, 시간, 어떤 환자인지, 출근 중인지 아닌지를 보여줍니다.
전에는 startDate와 endDate로만 판단했었어서, workDays 추가해서 오늘 날짜에 출근이 맞는지, 아니면 빈 배열로 보내드릴 수 있도록 바꿨습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
