### PR TITLE
[Feature] 요양보호사별 보호대상자 이름 조회

### DIFF
--- a/src/main/java/com/team_3/nursing_care/domain/member/controller/MemberController.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/controller/MemberController.java
@@ -9,7 +9,6 @@ import com.team_3.nursing_care.domain.member.dto.response.PatientsNameListRespon
 import com.team_3.nursing_care.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,6 +44,12 @@ public class MemberController {
     @PreAuthorize("hasAnyRole('ADMIN')")
     public ResponseEntity<?> getRoleNameList() {
         return ResponseEntity.ok((new ResponseDto<>(OK, ResultMessage.Success, memberService.getRoleName())));
+    }
+
+    @PreAuthorize("hasAnyRole('CAREGIVER')")
+    @GetMapping("/caregiver/patient-name-list")
+    public ResponseEntity<?> getCaregiverPatientNameList(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok((new ResponseDto<>(OK, ResultMessage.Success, memberService.getCaregiverPatientsName(userDetails.getMemberId()))));
     }
 
 }

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/MemberService.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/MemberService.java
@@ -3,10 +3,7 @@ package com.team_3.nursing_care.domain.member.service;
 import com.team_3.nursing_care.domain.member.constant.Role;
 import com.team_3.nursing_care.domain.member.dto.request.ReqLoginDto;
 import com.team_3.nursing_care.domain.member.dto.request.ReqSignUpDto;
-import com.team_3.nursing_care.domain.member.dto.response.CaregiversNameListResponseDto;
-import com.team_3.nursing_care.domain.member.dto.response.PatientsNameListResponseDto;
-import com.team_3.nursing_care.domain.member.dto.response.ResLoginDto;
-import com.team_3.nursing_care.domain.member.dto.response.RoleNameResponseDto;
+import com.team_3.nursing_care.domain.member.dto.response.*;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -16,6 +13,8 @@ public interface MemberService {
     CaregiversNameListResponseDto getCaregiversName(Long companyId, Role role, Pageable pageable);
 
     PatientsNameListResponseDto getPatientsName(Long companyId, Role role, Pageable pageable);
+
+    List<PatientsNameResponseDto> getCaregiverPatientsName(Long memberId);
 
     List<RoleNameResponseDto> getRoleName();
 

--- a/src/main/java/com/team_3/nursing_care/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/team_3/nursing_care/domain/member/service/MemberServiceImpl.java
@@ -13,6 +13,8 @@ import com.team_3.nursing_care.domain.member.proxy.dto.ReqBusinessAuthenticityDt
 import com.team_3.nursing_care.domain.member.proxy.service.BusinessAuthenticityService;
 import com.team_3.nursing_care.domain.member.repository.CompanyRepository;
 import com.team_3.nursing_care.domain.member.repository.MemberRepository;
+import com.team_3.nursing_care.domain.schedule.entity.Schedule;
+import com.team_3.nursing_care.domain.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -22,10 +24,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.http.HttpStatusCode;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +41,7 @@ public class MemberServiceImpl implements MemberService {
     private final BusinessAuthenticityService businessAuthenticityService;
     private final MemberRepository memberRepository;
     private final CompanyRepository companyRepository;
+    private final ScheduleRepository scheduleRepository;
     private final PasswordEncoder passwordEncoder;
     private final S3Service s3Service;
     private final JwtUtil jwtUtil;
@@ -59,6 +65,28 @@ public class MemberServiceImpl implements MemberService {
         Page<PatientsNameResponseDto> PatientNameDtoPage = patientPage.map(PatientsNameResponseDto::from);
 
         return PatientsNameListResponseDto.from(PatientNameDtoPage);
+    }
+
+    @Override
+    public List<PatientsNameResponseDto> getCaregiverPatientsName(Long memberId) {
+
+        List<Schedule> schedules = scheduleRepository.findByMemberIdAndScheduleDate(memberId, LocalDate.now());
+
+        List<Member> members = schedules.stream()
+                .collect(Collectors.toMap(
+                        Schedule::getPatientId,
+                        Schedule::getPatient,
+                        (existing, replacement) -> existing
+                ))
+                .entrySet().stream()
+                .map(entry -> Member.builder().memberId(entry.getKey()).memberName(entry.getValue()).build())
+                .sorted(Comparator.comparing(Member::getMemberName))
+                .collect(Collectors.toList());
+
+        return members.stream()
+                .map(PatientsNameResponseDto::from)
+                .collect(Collectors.toList());
+
     }
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 요양보호사가 현재 담당하고 있는 보호대상자의 이름과 아이디 조회하는 기능 필요하다고 하셔서 작업했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
